### PR TITLE
Admins can't edit track details

### DIFF
--- a/src/Controller/Track.php
+++ b/src/Controller/Track.php
@@ -136,6 +136,8 @@ class Track extends AbstractController
             }
 
             $track->setvideosYoutube($youtubeVideos);
+            $track->setName($form->get('name')->getData());
+            $track->setType($form->get('type')->getData());
 
             $this->getDoctrine()->getManager()
                 ->flush();


### PR DESCRIPTION
Admins can't edit track details, for example: type and name.
Admins should be able to do such changes