### PR TITLE
docker-compose: Export MySQL default port 3306 to 33066

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
   sql:
     restart: unless-stopped
     image: mariadb:10.3
+    ports:
+      - 33066:3306
     environment:
       MYSQL_ROOT_PASSWORD: 1
       MYSQL_USER: gps


### PR DESCRIPTION
Allow accessing MySQL server on port 33066