### PR TITLE
Docker: Make encore watch for files

### DIFF
--- a/docker/web/dev/entrypoint.sh
+++ b/docker/web/dev/entrypoint.sh
@@ -14,6 +14,7 @@ su www-data bash -c "cd /var/www/script/migration && composer install --no-dev &
 su www-data bash -c "composer install -d /var/www"
 
 su www-data bash -c "cd /var/www && yarn install"
+su www-data bash -c "cd /var/www && yarn encore dev"
 su www-data bash -c "cd /var/www && yarn encore dev --watch &"
 
 apachectl -D FOREGROUND

--- a/docker/web/dev/entrypoint.sh
+++ b/docker/web/dev/entrypoint.sh
@@ -14,6 +14,6 @@ su www-data bash -c "cd /var/www/script/migration && composer install --no-dev &
 su www-data bash -c "composer install -d /var/www"
 
 su www-data bash -c "cd /var/www && yarn install"
-su www-data bash -c "cd /var/www && yarn encore dev"
+su www-data bash -c "cd /var/www && yarn encore dev --watch &"
 
 apachectl -D FOREGROUND


### PR DESCRIPTION
It is useful to make encore watch for file changes. The current method is to run encore manually within the container.