### PR TITLE
gitignore: ignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ yarn-error.log
 /phpunit.xml
 .phpunit.result.cache
 ###< phpunit/phpunit ###
+
+.idea/


### PR DESCRIPTION
Since 100% of the contributors uses phpstorm, add .idea folder to .gitignore 