### PR TITLE
Use bs-custom-file-input from FileType form

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,3 +22,5 @@ window.AppTrack = require('./components/appTrack.js');
 window.StarRating = require('./components/starRating');
 
 window.MapControlFullScreen =  require('./map/control/fullScreen')
+
+window.bsCustomFileInput = require('bs-custom-file-input');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@fortawesome/fontawesome-free": "^5.10.1",
         "bootstrap": "^4.1.3",
+        "bs-custom-file-input": "^1.3.2",
         "chart.js": "^2.8.0",
         "ekko-lightbox": "^5.3.0",
         "jquery": "^3.4.1",

--- a/templates/include/foot.html.twig
+++ b/templates/include/foot.html.twig
@@ -34,5 +34,10 @@
     jQuery(document).ready(function() {
         jQuery('[data-toggle="tooltip"]').tooltip();
         jQuery('[data-toggle="popover"]').popover();
+
+        /**
+         * Show selected file name, when using FileType::class with form builder.
+         */
+        window.bsCustomFileInput.init();
     });
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,6 +1387,11 @@ browserslist@^4.0.0, browserslist@^4.6.0, browserslist@^4.6.6:
     electron-to-chromium "^1.3.191"
     node-releases "^1.1.25"
 
+bs-custom-file-input@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/bs-custom-file-input/-/bs-custom-file-input-1.3.2.tgz#c141c94071cc5e9ac4ea98479a1c204dd18e3b9a"
+  integrity sha512-lzgtGX2GDo7nUmsTCcTvYkCc35d3/E14h+HXmFKV8z2EJmtkMcvYT8BsWOjK67+ogZR3kc8OfH5O8APjvDUtFg==
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"


### PR DESCRIPTION
When selecting file the name is not updated in the label. Workaround is to use [this](https://github.com/Johann-S/bs-custom-file-input) library.

Fixes #142 

