### PR TITLE
Remove yarn from watching files

### DIFF
--- a/docker/web/dev/entrypoint.sh
+++ b/docker/web/dev/entrypoint.sh
@@ -15,6 +15,5 @@ su www-data bash -c "composer install -d /var/www"
 
 su www-data bash -c "cd /var/www && yarn install"
 su www-data bash -c "cd /var/www && yarn encore dev"
-su www-data bash -c "cd /var/www && yarn encore dev --watch &"
 
 apachectl -D FOREGROUND


### PR DESCRIPTION
Where there are changes in some configuration file, yarn should be restarted. Currently this could be done by killing the process.

Workaround is to run yarn manually in the foreground.