### PR TITLE
reduce image preview size

### DIFF
--- a/templates/gps/view.html.twig
+++ b/templates/gps/view.html.twig
@@ -81,7 +81,7 @@
     {% if track.images is not empty %}
         <div class="uploaded_images" >
             {% for image in track.images %}
-                <a href="{{ app_track_image(image, 3840, 2160) }}"
+                <a href="{{ app_track_image(image, 1280, 720) }}"
                    data-toggle="lightbox"
                    data-gallery="track-images"
                    data-footer="&lt;a target=&quot;_blank&quot; href=&quot;{{ app_track_image(image, 3840, 2160) }}#&quot;&gt;{{ 'View full size'|trans() }}&lt;/a&gt;"


### PR DESCRIPTION
Reduce the preview size to HD (1280x720).
This resolution if fine for full HD monitors.
The 4k is killing mobile devices :/