### PR TITLE
Bump MariaDB to 10.3.17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - sql
   sql:
     restart: unless-stopped
-    image: mariadb:10.3.18
+    image: mariadb:10.3.17
     environment:
       MYSQL_ROOT_PASSWORD: 1
       MYSQL_USER: gps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,6 @@ services:
       MYSQL_USER: gps
       MYSQL_PASSWORD: 1
       MYSQL_DATABASE: gps
+      MYSQL_INITDB_SKIP_TZINFO: 1
     volumes:
     - ./docker/var/sql:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,11 @@ services:
       - sql
   sql:
     restart: unless-stopped
-    image: mariadb:10.3
+    image: mariadb:10.3.18
     environment:
       MYSQL_ROOT_PASSWORD: 1
       MYSQL_USER: gps
       MYSQL_PASSWORD: 1
       MYSQL_DATABASE: gps
-      MYSQL_INITDB_SKIP_TZINFO: 1
     volumes:
     - ./docker/var/sql:/var/lib/mysql


### PR DESCRIPTION
When creating a new mariadb container, initialization can take a long time, 30+ minutes. 

The workaround is suggested here:
https://github.com/docker-library/mariadb/issues/262#issuecomment-536405303