### PR TITLE
add content type header

### DIFF
--- a/src/Controller/Track.php
+++ b/src/Controller/Track.php
@@ -482,6 +482,7 @@ class Track extends AbstractController
             200,
             [
                 'Content-Disposition' => ResponseHeaderBag::DISPOSITION_ATTACHMENT . '; filename="track.gpx";',
+                'Content-Type' => 'application/octet-stream',
             ]
         );
 
@@ -502,6 +503,7 @@ class Track extends AbstractController
             200,
             [
                 'Content-Disposition' => ResponseHeaderBag::DISPOSITION_ATTACHMENT . '; filename="track.gpx";',
+                'Content-Type' => 'application/octet-stream',
             ]
         );
 


### PR DESCRIPTION
New android devices are unable to download tracks (Download filed with no reason) on chrome